### PR TITLE
removing transport from excluded credentials to support apple

### DIFF
--- a/packages/sdk-webauthn/index.ts
+++ b/packages/sdk-webauthn/index.ts
@@ -65,7 +65,6 @@ export class WebAuthn implements CredentialSigner<Fido2Assertion>, CredentialSto
         excludeCredentials: challenge.excludeCredentials.map((cred) => ({
           id: fromBase64Url(cred.id),
           type: cred.type,
-          transports: cred.transports ?? [],
         })),
         authenticatorSelection: challenge.authenticatorSelection,
         timeout: this.options.timeout ?? DEFAULT_WAIT_TIMEOUT,


### PR DESCRIPTION
MacOS and iOS don't seem to like the transports being set on excluded credentials. It's an optional value, and doesn't appear to have a negative effect not including it.