### PR TITLE
fix: wrong input type for create user recovery

### DIFF
--- a/packages/sdk/codegen/Auth/types.ts
+++ b/packages/sdk/codegen/Auth/types.ts
@@ -243,7 +243,7 @@ export type DeactivateApplicationRequest = {
 export type DeactivateApplicationResponse = Auth.AppInfoWithPublicKey
 
 export type CreateUserRecoveryRequest = {
-  body: Auth.CreateUserLoginChallengeInput
+  body: Auth.CreateUserRecoveryInput
 }
 
 export type CreateUserRecoveryResponse = Auth.UserRegistration


### PR DESCRIPTION
The "Create User Recovery" endpoint has the wrong input type: it was set as `CreateUserLoginChallengeInput` instead of `CreateUserRecoveryInput`.